### PR TITLE
feature/UnitDataBugFix

### DIFF
--- a/Assets/_Content/ScriptableObjects/Units/Hacker_Class.asset
+++ b/Assets/_Content/ScriptableObjects/Units/Hacker_Class.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   m_className: Hacker
   m_classSprite: {fileID: 21300000, guid: 11fd0c8ceaef48040a511c1401df0040, type: 3}
   m_movementType: {fileID: 11400000, guid: fb9c62f1e18c06848ac93d912ad5389b, type: 2}
-  m_baseStats: {fileID: 11400000, guid: 19695e1ced7b0bc49b51ca8c321fb83d, type: 2}
+  m_baseStats: {fileID: 11400000, guid: 80c67ddac7ffc4a42acaafb7f6d4e1b3, type: 2}
   m_experienceType: 1
   m_weakness:
   - {fileID: 11400000, guid: 48c15c274bf4a194084d8353d4237f2f, type: 2}

--- a/Assets/_Content/ScriptableObjects/Units/Heavy_Class.asset
+++ b/Assets/_Content/ScriptableObjects/Units/Heavy_Class.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   m_className: Heavy
   m_classSprite: {fileID: 21300000, guid: a2786e82345370d4bb43810c37fb57f6, type: 3}
   m_movementType: {fileID: 11400000, guid: 85c084708d04fe7458689b621d055632, type: 2}
-  m_baseStats: {fileID: 11400000, guid: c7d8bd436ff0e6442be694a18b6ef0b2, type: 2}
+  m_baseStats: {fileID: 11400000, guid: 7281976b39fc13a4caea6b14fb58e8e5, type: 2}
   m_experienceType: 2
   m_weakness:
   - {fileID: 11400000, guid: e0881e467177a7242936867e93398321, type: 2}

--- a/Assets/_Content/ScriptableObjects/Units/Ranger_Class.asset
+++ b/Assets/_Content/ScriptableObjects/Units/Ranger_Class.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   m_className: Ranger
   m_classSprite: {fileID: 21300000, guid: 4c4ce53b27123314498e80a9827b4d5c, type: 3}
   m_movementType: {fileID: 11400000, guid: f08647ab8bed5e0479b29e289a1a919a, type: 2}
-  m_baseStats: {fileID: 11400000, guid: 638edcb002299804393e64e3e6a8a59f, type: 2}
+  m_baseStats: {fileID: 11400000, guid: 3d497a983b1f8cf49b5e3ee33e435bf0, type: 2}
   m_experienceType: 0
   m_weakness:
   - {fileID: 11400000, guid: c3f7bcf1055dd6742916822f5d565880, type: 2}

--- a/Assets/_Content/ScriptableObjects/Units/Stats/HackerStats.asset
+++ b/Assets/_Content/ScriptableObjects/Units/Stats/HackerStats.asset
@@ -10,18 +10,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 0}
-  m_Name: RangerBaseStats
+  m_Name: HackerStats
   m_EditorClassIdentifier: Assembly-CSharp:DogHouse.ToonWorld.CombatControllers:UnitStats
   m_myDestroyableStats:
     Health:
       Value: 8
     Defence:
-      Value: 4
+      Value: 12
   m_strength:
-    Value: 15
+    Value: 6
   m_accuracy:
-    Value: 15
-  m_speed:
-    Value: 4
-  m_luck:
     Value: 10
+  m_speed:
+    Value: 12
+  m_luck:
+    Value: 8

--- a/Assets/_Content/ScriptableObjects/Units/Stats/HackerStats.asset.meta
+++ b/Assets/_Content/ScriptableObjects/Units/Stats/HackerStats.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 638edcb002299804393e64e3e6a8a59f
+guid: 80c67ddac7ffc4a42acaafb7f6d4e1b3
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/Assets/_Content/ScriptableObjects/Units/Stats/HeavyStats.asset
+++ b/Assets/_Content/ScriptableObjects/Units/Stats/HeavyStats.asset
@@ -10,18 +10,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 0}
-  m_Name: HackerBaseStats
+  m_Name: HeavyStats
   m_EditorClassIdentifier: Assembly-CSharp:DogHouse.ToonWorld.CombatControllers:UnitStats
   m_myDestroyableStats:
     Health:
-      Value: 12
+      Value: 15
     Defence:
-      Value: 7
+      Value: 8
   m_strength:
-    Value: 7
-  m_accuracy:
     Value: 12
+  m_accuracy:
+    Value: 5
   m_speed:
-    Value: 15
+    Value: 6
   m_luck:
-    Value: 7
+    Value: 5

--- a/Assets/_Content/ScriptableObjects/Units/Stats/HeavyStats.asset.meta
+++ b/Assets/_Content/ScriptableObjects/Units/Stats/HeavyStats.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 19695e1ced7b0bc49b51ca8c321fb83d
+guid: 7281976b39fc13a4caea6b14fb58e8e5
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0

--- a/Assets/_Content/ScriptableObjects/Units/Stats/RangerStats.asset
+++ b/Assets/_Content/ScriptableObjects/Units/Stats/RangerStats.asset
@@ -10,18 +10,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 0}
-  m_Name: HeavyBaseStats
+  m_Name: RangerStats
   m_EditorClassIdentifier: Assembly-CSharp:DogHouse.ToonWorld.CombatControllers:UnitStats
   m_myDestroyableStats:
     Health:
-      Value: 20
+      Value: 5
     Defence:
-      Value: 10
+      Value: 4
   m_strength:
-    Value: 8
+    Value: 13
   m_accuracy:
-    Value: 5
+    Value: 8
   m_speed:
-    Value: 6
+    Value: 7
   m_luck:
-    Value: 4
+    Value: 10

--- a/Assets/_Content/ScriptableObjects/Units/Stats/RangerStats.asset.meta
+++ b/Assets/_Content/ScriptableObjects/Units/Stats/RangerStats.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c7d8bd436ff0e6442be694a18b6ef0b2
+guid: 3d497a983b1f8cf49b5e3ee33e435bf0
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 0


### PR DESCRIPTION
This branch fixes the bug of missing base data from game unit definitions. This was caused from a previous branch which changed the class structure causing a loss in the serializations.